### PR TITLE
Fixed required version for uWSGI to be 2.0.18 (current latest)

### DIFF
--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -5,7 +5,7 @@ pep8==1.5.6
 psycopg2==2.5.1
 pyflakes==0.8.1
 rgkit==0.5.3
-uWSGI==2.0.5.1
+uWSGI==2.0.18
 web.py==0.37
 Markdown==2.5.2
 bleach==1.4.1


### PR DESCRIPTION
Fixed required version for uWSGI to be 2.0.18 (current latest) which allowed docker-compose to build and install.